### PR TITLE
fix: remove invalid vercel functions pattern

### DIFF
--- a/apps/frontend/vercel.json
+++ b/apps/frontend/vercel.json
@@ -4,12 +4,6 @@
   "framework": "nextjs",
   "installCommand": "npm install",
   "devCommand": "npm run dev",
-
-  "functions": {
-    "apps/frontend/app/**/*.{js,ts,jsx,tsx}": {
-      "runtime": "@vercel/node@3.0.0"
-    }
-  },
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- remove the misconfigured Serverless Functions pattern from the frontend Vercel configuration so Vercel no longer errors during deploys

## Testing
- npm run lint --workspace frontend

------
https://chatgpt.com/codex/tasks/task_e_68d3914262f483299f237e4b17b8a13c

## Summary by Sourcery

Bug Fixes:
- Remove misconfigured Serverless Functions pattern from apps/frontend/vercel.json