### PR TITLE
Add health check route for Next.js frontend

### DIFF
--- a/apps/frontend/app/api/health/route.ts
+++ b/apps/frontend/app/api/health/route.ts
@@ -7,7 +7,7 @@ export function GET() {
     { status: 'ok' },
     {
       headers: {
-        'Cache-Control': 'no-store, max-age=0',
+        'Cache-Control': 'no-cache, no-store, must-revalidate, max-age=0',
       },
     },
   );

--- a/apps/frontend/app/api/health/route.ts
+++ b/apps/frontend/app/api/health/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return NextResponse.json(
+    { status: 'ok' },
+    {
+      headers: {
+        'Cache-Control': 'no-store, max-age=0',
+      },
+    },
+  );
+}

--- a/apps/frontend/app/api/health/route.ts
+++ b/apps/frontend/app/api/health/route.ts
@@ -7,7 +7,7 @@ export function GET() {
     { status: 'ok' },
     {
       headers: {
-        'Cache-Control': 'no-cache, no-store, must-revalidate, max-age=0',
+        'Cache-Control': 'no-store, max-age=0',
       },
     },
   );

--- a/apps/frontend/tests/api/health.spec.ts
+++ b/apps/frontend/tests/api/health.spec.ts
@@ -9,6 +9,6 @@ describe('GET /api/health', () => {
     const payload = await response.json();
     expect(payload).toEqual({ status: 'ok' });
 
-    expect(response.headers.get('cache-control')).toBe('no-store, max-age=0');
+    expect(response.headers.get('Cache-Control')).toBe('no-store, max-age=0');
   });
 });

--- a/apps/frontend/tests/api/health.spec.ts
+++ b/apps/frontend/tests/api/health.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { GET } from '@/app/api/health/route';
+
+describe('GET /api/health', () => {
+  it('returns a successful health status payload', async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+
+    const payload = await response.json();
+    expect(payload).toEqual({ status: 'ok' });
+
+    expect(response.headers.get('cache-control')).toBe('no-store, max-age=0');
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated `/api/health` route so the project always exposes at least one serverless function for Vercel
- set the route to return a cache-busted OK status payload to satisfy deployment health checks
- cover the new API handler with a Vitest spec to ensure the response contract remains stable

## Testing
- npm run lint --workspace frontend
- npm run test --workspace frontend

------
https://chatgpt.com/codex/tasks/task_e_68d396d1a2d083298356198737120312

## Summary by Sourcery

Add a dedicated health check API route to the Next.js frontend with no-store caching and include tests to ensure its response contract

New Features:
- Introduce /api/health endpoint returning an OK status payload with cache-busting headers

Tests:
- Add Vitest spec for the health check route to validate its response contract