### PR TITLE
Update Vercel deployment workflow

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -9,7 +9,12 @@ jobs:
   deploy-frontend:
     runs-on: ubuntu-latest
     environment: production
-    
+    env:
+      NEXT_PUBLIC_BACKEND_URL: ${{ secrets.BACKEND_URL || 'https://your-backend-url.com' }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
     steps:
     - uses: actions/checkout@v4
 
@@ -24,17 +29,14 @@ jobs:
 
     - name: Build frontend
       run: npm run build --workspace frontend
-      env:
-        NEXT_PUBLIC_BACKEND_URL: ${{ secrets.BACKEND_URL || 'https://your-backend-url.com' }}
+
+    - name: Install Vercel CLI
+      run: npm install --global vercel@latest
+
+    - name: Pull Vercel environment configuration
+      working-directory: ./apps/frontend
+      run: vercel pull --yes --environment=production --token "$VERCEL_TOKEN"
 
     - name: Deploy to Vercel
-      uses: amondnet/vercel-action@v25
-      with:
-        vercel-token: ${{ secrets.VERCEL_TOKEN }}
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-        vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-        working-directory: ./apps/frontend
-        vercel-args: --prod
-      env:
-        NEXT_PUBLIC_BACKEND_URL: ${{ secrets.BACKEND_URL || 'https://your-backend-url.com' }}
+      working-directory: ./apps/frontend
+      run: vercel deploy --prod --yes --token "$VERCEL_TOKEN"


### PR DESCRIPTION
## Summary
- set job-level environment variables for Vercel secrets and backend URL
- replace the deprecated amondnet Vercel action with explicit CLI steps
- install the Vercel CLI, pull environment config, and deploy from the frontend workspace

## Testing
- `CI=1 npm run build --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_68d3a2b192f08329bce45d793febfa23

## Summary by Sourcery

Update GitHub Actions workflow for Vercel deployment to centralize environment variables and migrate from a deprecated action to explicit Vercel CLI commands.

CI:
- Set job-level environment variables for the backend URL and Vercel credentials.
- Install the Vercel CLI, pull environment configuration, and deploy the frontend via CLI instead of using the amondnet/vercel-action.