### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -1,4 +1,6 @@
 name: Deploy to Vercel
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/matheus-rech/gtp-realtime-screen-reader/security/code-scanning/8](https://github.com/matheus-rech/gtp-realtime-screen-reader/security/code-scanning/8)

**General Fix:**  
Add a `permissions` block at the workflow or job level, specifying the least privileges needed. For this workflow, based on its steps (checkout, install, build, deploy to Vercel), only read access to repository contents appears to be required. No steps require write access to issues, pull requests, or repository contents.

**Best Detailed Fix:**  
Add the following under the workflow root (after the `name` and before `on`) or inside the specific job block (under `deploy-frontend`), as documented in GitHub's workflow syntax:
```yaml
permissions:
  contents: read
```
Placing it at the root applies the permission restriction to all jobs in the workflow, which is usually preferred for simplicity and safety.

**Specific file/region to change:**  
In `.github/workflows/deploy-vercel.yml`, add the `permissions:` block immediately after the `name: Deploy to Vercel` line (before `on:`).

**Requirements:**  
No new methods, imports, or definitions are needed—just the YAML addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Restrict the Deploy to Vercel workflow to read-only repository contents by adding a permissions block